### PR TITLE
Decouple CommandFinder from AppController

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -4,24 +4,17 @@ declare(strict_types=1);
 
 namespace Drinksco\ConsoleUiBundle\Controller;
 
-use Drinksco\ConsoleUiBundle\ReadModel\Argument;
-use Drinksco\ConsoleUiBundle\ReadModel\Command as ReadModelCommand;
-use Drinksco\ConsoleUiBundle\ReadModel\Option;
-use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
+use Drinksco\ConsoleUiBundle\Finder\CommandFinder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\HttpKernel\KernelInterface;
 use Twig\Environment;
 use Webmozart\Assert\Assert;
 
 class AppController
 {
     public function __construct(
-        private readonly KernelInterface $kernel,
+        private readonly CommandFinder $finder,
         private readonly Environment $template,
     ) {
     }
@@ -31,123 +24,15 @@ class AppController
         $namespace = $request->attributes->get('namespace');
         Assert::nullOrString($namespace);
 
-        $application = new Application($this->kernel);
-        $commands = $application->all($namespace);
-
-        if ('root' === $namespace) {
-            $commands = $this->getNoNamespacedCommands($application);
-        }
+        $commands = $this->finder->findByNamespace($namespace);
 
         if ([] === $commands) {
             throw new NotFoundHttpException('Given Console namespace does not exist.');
         }
 
         return new Response($this->template->render('@ConsoleUi/console-ui.html.twig', [
-            'commands' => $this->serializeCommands($commands),
-            'menu_items' => $this->serializeMenuItems($application),
+            'commands' => $commands,
+            'menu_items' => $this->finder->findAllNamespaces(),
         ]));
-    }
-
-    /**
-     * @param array<Command> $all
-     * @return array<ReadModelCommand>
-     */
-    private function serializeCommands(array $all): array
-    {
-        return array_values(array_map(function (Command $command): ReadModelCommand {
-            $name = $command->getName();
-            Assert::string(
-                $name,
-                sprintf('Command od class "%s" without name not expected at this point.', $command::class)
-            );
-
-            return new ReadModelCommand(
-                $name,
-                $command->getDescription(),
-                $name,
-                $this->serializeArguments($command->getDefinition()->getArguments()),
-                $this->serializeOptions($command->getDefinition()->getOptions()),
-            );
-        }, $all));
-    }
-
-    /**
-     * @param array<array-key, InputArgument> $getArguments
-     * @return array<Argument>
-     */
-    private function serializeArguments(array $getArguments): array
-    {
-        return array_values(array_map(function (InputArgument $argument): Argument {
-            // @TODO prepare to other types of default values
-            /** @var string $defaultValue */
-            $defaultValue = is_string($argument->getDefault()) ? $argument->getDefault() : null;
-            return new Argument(
-                $argument->getName(),
-                $argument->getDescription(),
-                $defaultValue,
-                $defaultValue,
-            );
-        }, $getArguments));
-    }
-
-    /**
-     * @param array<array-key, InputOption> $getOptions
-     * @return array<Option>
-     */
-    private function serializeOptions(array $getOptions): array
-    {
-        return array_values(array_map(function (InputOption $option): Option {
-            // @TODO prepare to other types of default values
-            /** @var string $defaultValue */
-            $defaultValue = is_string($option->getDefault()) ? $option->getDefault() : null;
-            return new Option(
-                $option->getName(),
-                $option->getDescription(),
-                $option->acceptValue(),
-                $defaultValue,
-                $defaultValue,
-            );
-        }, $getOptions));
-    }
-
-    /** @return array<string> */
-    private function serializeMenuItems(Application $application): array
-    {
-        $namespaces = [];
-        $commands = $application->all();
-        $rawNamespaces = array_keys($commands);
-        foreach ($rawNamespaces as $rawNamespace) {
-            Assert::string($rawNamespace);
-            $command = $commands[$rawNamespace];
-            if (in_array($rawNamespace, $command->getAliases())) {
-                continue;
-            }
-
-            if (str_contains($rawNamespace, ':')) {
-                $namespaces[explode(':', $rawNamespace)[0]] = null;
-            }
-        }
-
-        $namespaces = array_keys($namespaces);
-        sort($namespaces);
-
-        return array_merge(['root'], $namespaces);
-    }
-
-    /** @return array<Command> */
-    private function getNoNamespacedCommands(Application $application): array
-    {
-        $commands = [];
-        $allCommands = $application->all();
-        foreach ($allCommands as $name => $command) {
-            Assert::string($name);
-            if (str_contains($name, ':') || str_starts_with($name, '_')) {
-                continue;
-            }
-
-            $commands[] = $command;
-        }
-
-        return $commands;
     }
 }

--- a/src/Finder/CommandFinder.php
+++ b/src/Finder/CommandFinder.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drinksco\ConsoleUiBundle\Finder;
+
+use Drinksco\ConsoleUiBundle\ReadModel\Command;
+
+interface CommandFinder
+{
+    /** @return array<Command> */
+    public function findByNamespace(?string $namespace): array;
+
+    /** @return array<string> */
+    public function findAllNamespaces(): array;
+}

--- a/src/Finder/Symfony/SymfonyKernelApplicationFinder.php
+++ b/src/Finder/Symfony/SymfonyKernelApplicationFinder.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Drinksco\ConsoleUiBundle\Finder\Symfony;
+
+use Drinksco\ConsoleUiBundle\Finder\CommandFinder;
+use Drinksco\ConsoleUiBundle\ReadModel\Argument;
+use Drinksco\ConsoleUiBundle\ReadModel\Command as ReadModelCommand;
+use Drinksco\ConsoleUiBundle\ReadModel\Option;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Webmozart\Assert\Assert;
+
+class SymfonyKernelApplicationFinder implements CommandFinder
+{
+    public function __construct(
+        private readonly Application $application
+    ) {
+    }
+
+    /** @return array<ReadModelCommand> */
+    public function findByNamespace(?string $namespace): array
+    {
+        $commands = $this->application->all($namespace);
+
+        if ('root' === $namespace) {
+            $commands = $this->getNoNamespacedCommands();
+        }
+
+        return $this->hydrateCommands($commands);
+    }
+
+    /** @return array<Command> */
+    private function getNoNamespacedCommands(): array
+    {
+        $commands = [];
+        $allCommands = $this->application->all();
+        foreach ($allCommands as $name => $command) {
+            Assert::string($name);
+            if (str_contains($name, ':') || str_starts_with($name, '_')) {
+                continue;
+            }
+
+            $commands[] = $command;
+        }
+
+        return $commands;
+    }
+
+    /**
+     * @param array<Command> $commands
+     * @return array<ReadModelCommand>
+     */
+    private function hydrateCommands(array $commands): array
+    {
+        return array_values(array_map(function (Command $command): ReadModelCommand {
+            $name = $command->getName();
+            Assert::string(
+                $name,
+                sprintf('Command od class "%s" without name not expected at this point.', $command::class)
+            );
+
+            return new ReadModelCommand(
+                $name,
+                $command->getDescription(),
+                $name,
+                $this->hydrateArguments($command->getDefinition()->getArguments()),
+                $this->hydrateOptions($command->getDefinition()->getOptions()),
+            );
+        }, $commands));
+    }
+
+    /**
+     * @param array<InputArgument> $arguments
+     * @return array<Argument>
+     */
+    private function hydrateArguments(array $arguments): array
+    {
+        return array_values(array_map(function (InputArgument $argument): Argument {
+            // @TODO prepare to other types of default values
+            /** @var string $defaultValue */
+            $defaultValue = is_string($argument->getDefault()) ? $argument->getDefault() : null;
+            return new Argument(
+                $argument->getName(),
+                $argument->getDescription(),
+                $defaultValue,
+                $defaultValue,
+            );
+        }, $arguments));
+    }
+
+    /**
+     * @param array<InputOption> $options
+     * @return array<Option>
+     */
+    private function hydrateOptions(array $options): array
+    {
+        return array_values(array_map(function (InputOption $option): Option {
+            // @TODO prepare to other types of default values
+            /** @var string $defaultValue */
+            $defaultValue = is_string($option->getDefault()) ? $option->getDefault() : null;
+            return new Option(
+                $option->getName(),
+                $option->getDescription(),
+                $option->acceptValue(),
+                $defaultValue,
+                $defaultValue,
+            );
+        }, $options));
+    }
+
+    public function findAllNamespaces(): array
+    {
+        $namespaces = [];
+        $commands = $this->application->all();
+        $rawNamespaces = array_keys($commands);
+        foreach ($rawNamespaces as $rawNamespace) {
+            Assert::string($rawNamespace);
+            $command = $commands[$rawNamespace];
+            if (in_array($rawNamespace, $command->getAliases())) {
+                continue;
+            }
+
+            if (str_contains($rawNamespace, ':')) {
+                $namespaces[explode(':', $rawNamespace)[0]] = null;
+            }
+        }
+
+        $namespaces = array_keys($namespaces);
+        sort($namespaces);
+
+        return array_merge(['root'], $namespaces);
+    }
+}

--- a/tests/Controller/AppControllerTest.php
+++ b/tests/Controller/AppControllerTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Test\Drinksco\ConsoleUiBundle\Controller;
 
 use Drinksco\ConsoleUiBundle\Controller\AppController;
+use Drinksco\ConsoleUiBundle\Finder\Symfony\SymfonyKernelApplicationFinder;
 use Drinksco\ConsoleUiBundle\ReadModel\Argument;
 use Drinksco\ConsoleUiBundle\ReadModel\Command;
 use Drinksco\ConsoleUiBundle\ReadModel\Option;
 use Generator;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -28,10 +30,11 @@ class AppControllerTest extends TestCase
                 'menu_items' => ['root'],
             ]);
 
-        $controller = new AppController(
-            $this->createMock(KernelInterface::class),
-            $environment
+        $finder = new SymfonyKernelApplicationFinder(
+            new Application($this->createMock(KernelInterface::class))
         );
+
+        $controller = new AppController($finder, $environment);
 
         $request = new Request();
 
@@ -44,10 +47,11 @@ class AppControllerTest extends TestCase
         $this->expectException(NotFoundHttpException::class);
         $environment = $this->createMock(Environment::class);
 
-        $controller = new AppController(
-            $this->createMock(KernelInterface::class),
-            $environment
+        $finder = new SymfonyKernelApplicationFinder(
+            new Application($this->createMock(KernelInterface::class))
         );
+
+        $controller = new AppController($finder, $environment);
 
         $request = new Request([], [], ['namespace' => 'foo']);
 

--- a/tests/Finder/Symfony/SymfonyKernelApplicationFinderTest.php
+++ b/tests/Finder/Symfony/SymfonyKernelApplicationFinderTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Drinksco\ConsoleUiBundle\Finder\Symfony;
+
+use Drinksco\ConsoleUiBundle\Finder\CommandFinder;
+use Drinksco\ConsoleUiBundle\Finder\Symfony\SymfonyKernelApplicationFinder;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class SymfonyKernelApplicationFinderTest extends TestCase
+{
+    public function testItFindAllKernelApplicationConsoleCommands(): void
+    {
+        $kernel = $this->createMock(KernelInterface::class);
+        $application = new Application($kernel);
+        $finder = new SymfonyKernelApplicationFinder($application);
+        $this->assertInstanceOf(CommandFinder::class, $finder);
+        $commands = $finder->findByNamespace('root');
+        $this->assertCount(3, $commands);
+    }
+}


### PR DESCRIPTION
Decoupling Command finding logic from the controller, allows us to load custom command collections inside the controller. This way we allow developers to configure what commands to show, and also, display commands from any other Symfony Console application.  

- [x] 👩‍🎓 I read contribution guidelines
- [ ] 🐞 Pull request introduces a BC-Break
- [x] ✅ Pull request is covered by tests
- [ ] 📒 Pull request is properly documented in docs
